### PR TITLE
api: add Gen::set_size and Gen::from_seed

### DIFF
--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -39,15 +39,33 @@ pub struct Gen {
 }
 
 impl Gen {
-    /// Returns a `Gen` with the given size configuration.
+    pub(crate) const DEFAULT_SIZE: usize = 100;
+
+    /// Returns a `Gen` with a random seed and the given size configuration.
+    pub fn new(size: usize) -> Gen {
+        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    }
+
+    /// Returns a `Gen` with the given seed and a default size configuration.
+    ///
+    /// Two `Gen`s created with the same seed will generate the same values. Though the values
+    /// may vary between QuickCheck releases.
+    pub fn from_seed(seed: u64) -> Gen {
+        Gen {
+            rng: rand::rngs::SmallRng::seed_from_u64(seed),
+            size: Self::DEFAULT_SIZE,
+        }
+    }
+
+    /// Sets the size configuration for this generator.
     ///
     /// The `size` parameter controls the size of random values generated.
     /// For example, it specifies the maximum length of a randomly generated
     /// vector, but is and should not be used to control the range of a
     /// randomly generated number. (Unless that number is used to control the
     /// size of a data structure.)
-    pub fn new(size: usize) -> Gen {
-        Gen { rng: rand::rngs::SmallRng::from_entropy(), size: size }
+    pub fn set_size(&mut self, size: usize) {
+        self.size = size;
     }
 
     /// Returns the size configured with this generator.

--- a/src/tester.rs
+++ b/src/tester.rs
@@ -33,7 +33,7 @@ fn qc_max_tests() -> u64 {
 }
 
 fn qc_gen_size() -> usize {
-    let default = 100;
+    let default = Gen::DEFAULT_SIZE;
     match env::var("QUICKCHECK_GENERATOR_SIZE") {
         Ok(val) => val.parse().unwrap_or(default),
         Err(_) => default,


### PR DESCRIPTION
The seed still can't be set by QuickCheck users, but the new Gen constructor is useful for other crates that use QuickCheck only for its Arbitrary trait.

Closes #277